### PR TITLE
Update liveness and readieness probes to use mongosh

### DIFF
--- a/mongodb-deployment.yaml
+++ b/mongodb-deployment.yaml
@@ -22,8 +22,7 @@ spec:
         livenessProbe:
           exec:
             command:
-              - mongo
-              - --disableImplicitSessions
+              - mongosh
               - --eval
               - "db.adminCommand('ping')"
           initialDelaySeconds: 30
@@ -34,8 +33,7 @@ spec:
         readinessProbe:
           exec:
             command:
-              - mongo
-              - --disableImplicitSessions
+              - mongosh
               - --eval
               - "db.adminCommand('ping')"
           initialDelaySeconds: 30


### PR DESCRIPTION
Latest mongo container does not ship with `mongo` binary any more, `mongosh` is the replacement